### PR TITLE
fix(alarms): re-read snooze state for warm instances (#8194)

### DIFF
--- a/lib/notifications.js
+++ b/lib/notifications.js
@@ -17,6 +17,10 @@ var alarms = {};
 function init (env, ctx) {
 
   var REFRESH_TIMEOUT_MS = parseInt(process.env.ALARM_REFRESH_TIMEOUT_MS, 10) || 5000;
+  // How long a cached snooze read stays "fresh" before emitNotification re-reads
+  // storage. Bounds both staleness and storage load for steady-state multi-instance
+  // deployments (issue #8194). Lower = snappier cross-instance ack, more reads.
+  var REFRESH_STALE_MS = parseInt(process.env.ALARM_REFRESH_STALE_MS, 10) || 30000;
 
   function notifications () {
     return notifications;
@@ -30,60 +34,78 @@ function init (env, ctx) {
       var display = group === 'default' ? ctx.levels.toDisplay(level) : group + ':' + level;
       alarm = new Alarm(level, group, display);
       alarms[key] = alarm;
-      // Defer first emit per (level, group) per process until storage refresh
-      // resolves or REFRESH_TIMEOUT_MS elapses. INFO is not snoozeable so skip.
-      var isSnoozeable = ctx.levels && level >= ctx.levels.WARN;
-      if (isSnoozeable && ctx.alarmStorage) {
-        alarm.refreshPending = true;
-        alarm.pendingNotify = null;
-        alarm.refreshDeadline = Date.now() + REFRESH_TIMEOUT_MS;
-
-        // Shared helper: clear the refresh window and retry any deferred notification.
-        // Called by both .then() and .catch() to eliminate duplication and ensure
-        // a try/catch guards emitNotification so no throw escapes as an unhandled rejection.
-        // Fail-open on storage errors: emitting with stale state is safer than silent drop
-        // on a medical safety device.
-        var resolveRefresh = function resolveRefresh () {
-          if (!alarm.refreshPending) {
-            if (alarm.pendingNotify) {
-              console.warn(alarm.label + ' alarm: pendingNotify set but refreshPending already false (deadline fired?); discarding');
-              alarm.pendingNotify = null;
-            }
-            return;
-          }
-          alarm.refreshPending = false;
-          var pending = alarm.pendingNotify;
-          alarm.pendingNotify = null;
-          if (pending) {
-            try {
-              emitNotification(pending);
-            } catch (emitErr) {
-              console.error('Failed to emit pending notification for ' + level + '-' + group + ': ' +
-                (emitErr && emitErr.message ? emitErr.message : String(emitErr)));
-            }
-          }
-        }
-
-        ctx.alarmStorage.getSnooze(level, group).then(function (doc) {
-          // Always update in-memory state from storage if doc is newer, even if the
-          // deadline already fired and we emitted optimistically from stale state.
-          if (doc && doc.lastAckTime > alarm.lastAckTime) {
-            alarm.lastAckTime = doc.lastAckTime;
-            alarm.silenceTime = doc.silenceTime;
-            console.info('alarm ' + level + '-' + group +
-              ' loaded snooze from storage, expiresAt=' +
-              new Date(doc.lastAckTime + doc.silenceTime).toISOString());
-          }
-          resolveRefresh();
-        }).catch(function (err) {
-          console.warn('alarmStorage.getSnooze failed for ' + level + '-' + group + ': ' +
-            (err && err.message ? err.message : String(err)));
-          resolveRefresh();
-        });
-      }
+      // Arm a storage refresh on first creation: the first emit per (level, group)
+      // per process is deferred until the read resolves or REFRESH_TIMEOUT_MS elapses.
+      maybeRefreshSnooze(alarm, level, group, true);
     }
 
     return alarm;
+  }
+
+  // Re-read snooze state from shared storage so multi-instance deployments honor an
+  // ack made on another instance. Without this, getSnooze() would be read only once
+  // per (level, group) per process (at alarm creation), so a long-lived "warm"
+  // instance would keep emitting from stale in-memory state after another instance
+  // was ack'd -- the steady-state half of issue #8194.
+  //
+  // `force` arms unconditionally (creation path). Otherwise we re-arm only when the
+  // cached snooze is older than REFRESH_STALE_MS and no read is already in flight,
+  // bounding both staleness and storage load. INFO is not snoozeable so we skip it.
+  function maybeRefreshSnooze (alarm, level, group, force) {
+    var isSnoozeable = ctx.levels && level >= ctx.levels.WARN;
+    if (!isSnoozeable || !ctx.alarmStorage) { return; }
+    if (alarm.refreshPending) { return; }
+    var now = Date.now();
+    if (!force && alarm.lastRefreshTime &&
+        (now - alarm.lastRefreshTime) < REFRESH_STALE_MS) { return; }
+
+    alarm.refreshPending = true;
+    alarm.pendingNotify = null;
+    alarm.refreshDeadline = now + REFRESH_TIMEOUT_MS;
+    alarm.lastRefreshTime = now;
+
+    // Shared helper: clear the refresh window and retry any deferred notification.
+    // Called by both .then() and .catch() to eliminate duplication and ensure
+    // a try/catch guards emitNotification so no throw escapes as an unhandled rejection.
+    // Fail-open on storage errors: emitting with stale state is safer than silent drop
+    // on a medical safety device.
+    var resolveRefresh = function resolveRefresh () {
+      if (!alarm.refreshPending) {
+        if (alarm.pendingNotify) {
+          console.warn(alarm.label + ' alarm: pendingNotify set but refreshPending already false (deadline fired?); discarding');
+          alarm.pendingNotify = null;
+        }
+        return;
+      }
+      alarm.refreshPending = false;
+      var pending = alarm.pendingNotify;
+      alarm.pendingNotify = null;
+      if (pending) {
+        try {
+          emitNotification(pending);
+        } catch (emitErr) {
+          console.error('Failed to emit pending notification for ' + level + '-' + group + ': ' +
+            (emitErr && emitErr.message ? emitErr.message : String(emitErr)));
+        }
+      }
+    }
+
+    ctx.alarmStorage.getSnooze(level, group).then(function (doc) {
+      // Always update in-memory state from storage if doc is newer, even if the
+      // deadline already fired and we emitted optimistically from stale state.
+      if (doc && doc.lastAckTime > alarm.lastAckTime) {
+        alarm.lastAckTime = doc.lastAckTime;
+        alarm.silenceTime = doc.silenceTime;
+        console.info('alarm ' + level + '-' + group +
+          ' loaded snooze from storage, expiresAt=' +
+          new Date(doc.lastAckTime + doc.silenceTime).toISOString());
+      }
+      resolveRefresh();
+    }).catch(function (err) {
+      console.warn('alarmStorage.getSnooze failed for ' + level + '-' + group + ': ' +
+        (err && err.message ? err.message : String(err)));
+      resolveRefresh();
+    });
   }
 
   //should only be used when auto acking the alarms after going back in range or when an error corrects
@@ -111,6 +133,9 @@ function init (env, ctx) {
 
   function emitNotification (notify) {
     var alarm = getAlarm(notify.level, notify.group);
+    // Re-read snooze state if our cached copy may be stale, so an ack made on
+    // another instance is honored before we emit (issue #8194, warm-instance path).
+    maybeRefreshSnooze(alarm, notify.level, notify.group, false);
     // Defer emission while storage refresh is pending and within the timeout window.
     // After the deadline, fall through and emit based on whatever in-memory state holds.
     if (alarm.refreshPending) {
@@ -246,9 +271,11 @@ function init (env, ctx) {
     alarm.lastAckTime = Date.now();
     alarm.silenceTime = time ? time : THIRTY_MINUTES;
     delete alarm.lastEmitTime;
-    // User explicitly acked; refresh window no longer relevant for this alarm.
+    // User explicitly acked; refresh window no longer relevant for this alarm and
+    // in-memory state is now authoritative, so reset the staleness clock.
     alarm.refreshPending = false;
     alarm.pendingNotify = null;
+    alarm.lastRefreshTime = alarm.lastAckTime;
 
     // Persist this snooze so other instances honor it.
     if (ctx.alarmStorage) {

--- a/tests/notifications.multi-instance-warm.test.js
+++ b/tests/notifications.multi-instance-warm.test.js
@@ -1,0 +1,180 @@
+'use strict';
+require('should');
+
+// Companion to notifications.multi-instance.test.js, covering the WARM-instance
+// half of issue #8194 and the fail-open guarantees of the storage re-read.
+//
+// #8194 background: alarm snooze/ack state is externalized to Mongo (PR #8501) so
+// multiple instances share it. But getSnooze() is read only when an alarm object
+// is first created, and the in-process `alarms` map is never cleared in production
+// (the only reset is resetStateForTests). So a long-lived "warm" instance that
+// built its alarm object before a cross-instance ack must RE-READ storage before
+// emitting, or it keeps firing from stale lastAckTime/silenceTime.
+//
+// Because that re-read sits on a medical-alarm hot path, it must be fail-open: a
+// storage error or a slow read must never DROP an alarm -- worst case it fires an
+// extra time, never zero times.
+
+// ---- shared harness (mirrors notifications.multi-instance.test.js) ----
+
+function makeSharedStorage () {
+  var stored = {};
+  return {
+    _stored: stored,
+    getSnooze: async function (level, group) {
+      var key = level + '-' + (group || 'default');
+      var doc = stored[key];
+      if (doc && doc.expiresAt > new Date()) return doc;
+      return null;
+    },
+    setSnooze: async function (level, group, lastAckTime, silenceTime) {
+      var ng = group || 'default';
+      var key = level + '-' + ng;
+      var newExpiresAt = new Date(lastAckTime + silenceTime);
+      var existing = stored[key];
+      if (!existing || newExpiresAt > existing.expiresAt) {
+        stored[key] = {
+          _id: key, level: level, group: ng,
+          lastAckTime: lastAckTime, silenceTime: silenceTime,
+          expiresAt: newExpiresAt
+        };
+      }
+      return null;
+    }
+  };
+}
+
+function makeInstance (storage) {
+  delete require.cache[require.resolve('../lib/notifications')];
+  var emits = [];
+  var ctx = {
+    ddata: { lastUpdated: Date.now() },
+    bus: { emit: function (evt, data) { emits.push({ evt: evt, data: data }); } },
+    levels: { URGENT: 2, WARN: 1, INFO: 0, toDisplay: function (l) { return 'L' + l; } },
+    alarmStorage: storage
+  };
+  var n = require('../lib/notifications')({ testMode: true }, ctx);
+  n.resetStateForTests();
+  n.__ctx = ctx;
+  n.__emits = emits;
+  return n;
+}
+
+// Simulate a fresh CGM reading arriving at an instance and being processed.
+function feedReading (instance) {
+  instance.__ctx.ddata.lastUpdated = Date.now();
+  instance.initRequests();
+  instance.requestNotify({
+    level: 2, group: 'default',
+    title: 'High', message: 'High BG',
+    plugin: { name: 'test' }
+  });
+  instance.process();
+}
+
+function emittedNotify (instance) {
+  return instance.__emits.some(function (e) {
+    return e.evt === 'notification' && !e.data.clear;
+  });
+}
+
+// Let the async getSnooze()/resolveRefresh chain settle (two microtask ticks).
+function settle () { return new Promise(function (r) { setImmediate(function () { setImmediate(r); }); }); }
+function delay (ms) { return new Promise(function (r) { setTimeout(r, ms); }); }
+
+describe('notifications multi-instance (WARM instance) -- #8194', function () {
+
+  var STALE_MS = 5;          // shrink the refresh-staleness window for the test
+  var CROSS_DELAY_MS = 50;   // comfortably exceeds STALE_MS before B re-reads
+  var savedStaleEnv;
+
+  before(function () {
+    savedStaleEnv = process.env.ALARM_REFRESH_STALE_MS;
+    process.env.ALARM_REFRESH_STALE_MS = String(STALE_MS);
+  });
+
+  after(function () {
+    if (savedStaleEnv === undefined) { delete process.env.ALARM_REFRESH_STALE_MS; }
+    else { process.env.ALARM_REFRESH_STALE_MS = savedStaleEnv; }
+  });
+
+  it('a warm instance honors a later ack made on another instance', async function () {
+    var sharedStorage = makeSharedStorage();
+    var instanceA = makeInstance(sharedStorage);
+    var instanceB = makeInstance(sharedStorage);
+
+    // 1) B sees the alarm FIRST and creates its (warm) alarm object while storage
+    //    is empty, then emits once the refresh window resolves.
+    feedReading(instanceB);
+    await settle();
+    emittedNotify(instanceB).should.equal(true,
+      'sanity: a warm instance emits the first alarm when no snooze exists yet');
+
+    // 2) The user acks on instance A. This persists the snooze to shared storage.
+    instanceA.ack(2, 'default', 60 * 60 * 1000); // 60-minute snooze
+    await settle();
+    sharedStorage._stored['2-default'].should.be.an.Object(); // sanity: persisted
+
+    // 3) After the staleness window elapses, a new CGM reading routes to the warm
+    //    instance B. B must re-read storage and honor A's ack.
+    instanceB.__emits.length = 0;
+    await delay(CROSS_DELAY_MS);
+    feedReading(instanceB);
+    await settle();
+    emittedNotify(instanceB).should.equal(false,
+      'Warm instance B re-emitted despite the ack on instance A ' +
+      '-- #8194 regression for long-lived multi-instance deployments');
+  });
+});
+
+describe('notifications storage re-read is fail-open -- #8194', function () {
+
+  // A short refresh deadline keeps the "hang past deadline" case fast.
+  var DEADLINE_MS = 30;
+  var savedTimeoutEnv;
+
+  before(function () {
+    savedTimeoutEnv = process.env.ALARM_REFRESH_TIMEOUT_MS;
+    process.env.ALARM_REFRESH_TIMEOUT_MS = String(DEADLINE_MS);
+  });
+
+  after(function () {
+    if (savedTimeoutEnv === undefined) { delete process.env.ALARM_REFRESH_TIMEOUT_MS; }
+    else { process.env.ALARM_REFRESH_TIMEOUT_MS = savedTimeoutEnv; }
+  });
+
+  it('emits the alarm when getSnooze() rejects (storage error must not drop it)', async function () {
+    var rejectingStorage = {
+      getSnooze: async function () { throw new Error('mongo unavailable'); },
+      setSnooze: async function () { return null; }
+    };
+    var inst = makeInstance(rejectingStorage);
+
+    feedReading(inst);
+    await settle();
+    emittedNotify(inst).should.equal(true,
+      'a getSnooze() rejection must fall through to emit, not silently drop the alarm');
+  });
+
+  it('emits from in-memory state when getSnooze() hangs past the deadline', async function () {
+    var hangingStorage = {
+      getSnooze: function () { return new Promise(function () { /* never resolves */ }); },
+      setSnooze: async function () { return null; }
+    };
+    var inst = makeInstance(hangingStorage);
+
+    // First reading is deferred while the (hung) read is in flight.
+    feedReading(inst);
+    await settle();
+    emittedNotify(inst).should.equal(false, 'sanity: deferred while within the deadline window');
+
+    // After the deadline elapses, the next reading emits from in-memory state
+    // rather than waiting forever on the stuck read.
+    inst.__emits.length = 0;
+    await delay(DEADLINE_MS * 2);
+    feedReading(inst);
+    await settle();
+    emittedNotify(inst).should.equal(true,
+      'a hung storage read must not block the alarm past the refresh deadline');
+  });
+});


### PR DESCRIPTION
Targets `wip/8194-alarm-snooze-externalize` per your note on #8501. Closes the warm-instance gap we discussed: `getSnooze()` was read only at alarm-object creation, so a long-lived instance kept emitting stale snooze state after a cross-instance ack.

**Change:** extract the creation-time refresh block into `maybeRefreshSnooze(alarm, level, group, force)`; `emitNotification` calls it with `force=false` to re-read storage when the cached snooze is older than `REFRESH_STALE_MS`.

**On your two points:**

1. **Fail-open + tunable** — default pinned at 30000ms, env-tunable via `ALARM_REFRESH_STALE_MS` (matches `ALARM_REFRESH_TIMEOUT_MS`). The re-read reuses your `resolveRefresh` path: a `getSnooze()` rejection (`.catch`) emits, and a read still pending past `refreshDeadline` emits from in-memory state — so a slow/down Mongo fires the alarm rather than dropping it. Both paths are covered by tests (see below), not just asserted. Bounded to ~1 read / 30s per active alarm.
2. **Test included** — `tests/notifications.multi-instance-warm.test.js`: a warm instance honoring a cross-instance ack (red before this change), plus fail-open coverage for `getSnooze()` rejecting and for it hanging past the deadline.

**One tradeoff for your call:** like your cold path, the warm re-read *defers* the current emit until storage resolves — fast (one Mongo read) normally, up to the deadline if Mongo hangs. The alternative is to emit immediately from in-memory state and refresh for the *next* reading — that never delays a genuine alarm but allows one extra re-fire after an ack. I kept the defer to stay consistent with your existing design; happy to switch if you prefer the emit-now variant.

Rebased onto your current tip (`bce07198`) — did not merge dev on your behalf, per your note. Notification + `alarmStorage` suites green locally, including the Mongo-backed `notifications-api` path (34 tests).
